### PR TITLE
adding support for selecting different math/rng/service backends via bazel build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,7 @@ build -c opt \
       --incompatible_require_linker_input_cc_api
 
 # Aliases for user-defined flags
+build --flag_alias=backend_config=@config//:backend_config
 build --flag_alias=test_link_mode=@config//:test_link_mode
 build --flag_alias=test_thread_mode=@config//:test_thread_mode
 build --flag_alias=test_external_datasets=@config//:test_external_datasets

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,6 +45,12 @@ micromkl_dpc_repo(
     sha256 = "1bd9e3ef850d95d1ee00e0f04943c8ed2490175fca6a7b331cab91a124ab301e",
 )
 
+load("@onedal//dev/bazel/deps:openblas.bzl", "openblas_repo")
+openblas_repo(
+    name = "openblas",
+    root_env_var = "OPENBLASROOT",
+)
+
 load("@onedal//dev/bazel/deps:tbb.bzl", "tbb_repo")
 tbb_repo(
     name = "tbb",

--- a/cpp/daal/BUILD
+++ b/cpp/daal/BUILD
@@ -6,30 +6,47 @@ load("@onedal//dev/bazel:daal.bzl",
     "daal_algorithms",
     "daal_generate_version",
     "daal_patch_kernel_defines",
+    "daal_patch_backend_config",
 )
 
 daal_module(
     name = "microvmlipp",
     override_deps_lib_tag = True,
-    deps = [
-        "@micromkl//:vml_ipp",
-        # TODO: Currently vml_ipp lib depends on TBB, but it shouldn't
-        #       Remove TBB from deps once problem with vml_ipp is resolved
-        "@tbb//:tbb_binary",
-    ],
+    deps = select({
+        "@config//:backend_ref": [ ],
+        "//conditions:default": [
+                                    "@micromkl//:vml_ipp",
+                                    # TODO: Currently vml_ipp lib depends on TBB, but it shouldn't
+                                    #       Remove TBB from deps once problem with vml_ipp is resolved
+                                    "@tbb//:tbb_binary",
+                                ],
+        }),
 )
 
 daal_module(
-    name = "micromkl_thread",
+    name = "mathbackend_thread",
     override_deps_lib_tag = True,
-    deps = [
-        "@micromkl//:mkl_thr",
-    ],
+    deps = select({
+        "@config//:backend_ref": [ "@openblas//:openblas",
+                                 ],
+        "//conditions:default": [ "@micromkl//:mkl_thr", 
+                                ],
+        }),
 )
 
 daal_patch_kernel_defines(
     name = "kernel_defines",
     src = "include/services/internal/daal_kernel_defines.h",
+)
+
+daal_patch_backend_config(
+    name = "backend_config_header",
+    src = "src/externals/config_template.h",
+    output = "src/externals/config.h",
+    backend_impl_name = select({
+        "@config//:backend_ref": "ref",
+        "//conditions:default":  "mkl",
+        }),
 )
 
 daal_module(
@@ -40,19 +57,25 @@ daal_module(
 
 daal_module(
     name = "includes",
-    hdrs = [
-        ":kernel_defines",
+    hdrs = [ ":kernel_defines",
+             ":backend_config_header",
     ],
     includes = [ "." ],
     defines = [
         "DAAL_NOTHROW_EXCEPTIONS",
         "DAAL_HIDE_DEPRECATED",
     ],
-    deps = [
-        ":public_includes",
-        "@micromkl//:headers",
-        "@micromkl_dpc//:headers",
-    ],
+    deps = select({
+        "@config//:backend_ref": [ 
+                                   ":public_includes",
+                                   "@openblas//:headers",
+                                 ],
+        "//conditions:default": [
+                                  ":public_includes",
+                                  "@micromkl//:headers",
+                                  "@micromkl_dpc//:headers",
+                                ],
+        }),
 )
 
 daal_generate_version(
@@ -111,11 +134,17 @@ daal_module(
     name = "sycl",
     hdrs = glob(["src/sycl/**/*.h", "src/sycl/**/*.cl"]),
     srcs = glob(["src/sycl/**/*.cpp"]),
-    deps = [
-        ":services",
-        "@onedal//cpp/daal/src/algorithms/engines:kernel",
-        "@micromkl_dpc//:headers",
-    ],
+    deps = select({
+            "@config//:backend_ref": [ 
+                                    ":services",
+                                    "@onedal//cpp/daal/src/algorithms/engines:kernel",
+                                        ],
+            "//conditions:default": [ 
+                                    ":services",
+                                    "@onedal//cpp/daal/src/algorithms/engines:kernel",
+                                    "@micromkl_dpc//:headers",
+                                    ],
+        }),
 )
 
 daal_module(
@@ -128,12 +157,20 @@ daal_module(
         "TBB_SUPPRESS_DEPRECATED_MESSAGES",
         "TBB_USE_ASSERT=0",
     ],
-    deps = [
-        ":threading_headers",
-        ":micromkl_thread",
-        "@tbb//:tbb",
-        "@tbb//:tbbmalloc",
-    ],
+    deps = select({
+            "@config//:backend_ref": [ 
+                                          ":threading_headers",
+                                          ":mathbackend_thread",
+                                          "@tbb//:tbb",
+                                          "@tbb//:tbbmalloc",
+                                        ],
+            "//conditions:default": [ 
+                                      ":threading_headers",
+                                      ":mathbackend_thread",
+                                      "@tbb//:tbb",
+                                      "@tbb//:tbbmalloc",
+                                    ],
+        }),
 )
 
 daal_module(

--- a/cpp/oneapi/dal/algo/kmeans/common.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/common.cpp
@@ -14,6 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include "oneapi/dal/backend/serialization.hpp"
 #include "oneapi/dal/algo/kmeans/common.hpp"
 #include "oneapi/dal/exceptions.hpp"
 
@@ -30,8 +31,16 @@ public:
 };
 
 template <typename Task>
-class model_impl : public base {
+class model_impl : public ONEDAL_SERIALIZABLE(kmeans_clustering_model_impl_id) {
 public:
+    void serialize(dal::detail::output_archive& ar) const override {
+        ar(centroids);
+    }
+
+    void deserialize(dal::detail::input_archive& ar) override {
+        ar(centroids);
+    }
+
     table centroids;
 };
 
@@ -107,7 +116,19 @@ void model<Task>::set_centroids_impl(const table& value) {
     impl_->centroids = value;
 }
 
+template <typename Task>
+void model<Task>::serialize(dal::detail::output_archive& ar) const {
+    dal::detail::serialize_polymorphic_shared(impl_, ar);
+}
+
+template <typename Task>
+void model<Task>::deserialize(dal::detail::input_archive& ar) {
+    dal::detail::deserialize_polymorphic_shared(impl_, ar);
+}
+
 template class ONEDAL_EXPORT model<task::clustering>;
+
+ONEDAL_REGISTER_SERIALIZABLE(detail::model_impl<task::clustering>)
 
 } // namespace v1
 } // namespace oneapi::dal::kmeans

--- a/cpp/oneapi/dal/algo/kmeans/common.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/common.hpp
@@ -181,6 +181,7 @@ template <typename Task = task::by_default>
 class model : public base {
     static_assert(detail::is_valid_task_v<Task>);
     friend dal::detail::pimpl_accessor;
+    friend dal::detail::serialization_accessor;
 
 public:
     using task_t = Task;
@@ -207,6 +208,8 @@ protected:
     void set_centroids_impl(const table&);
 
 private:
+    void serialize(dal::detail::output_archive& ar) const;
+    void deserialize(dal::detail::input_archive& ar);
     dal::detail::pimpl<detail::model_impl<Task>> impl_;
 };
 

--- a/cpp/oneapi/dal/backend/dispatcher.hpp
+++ b/cpp/oneapi/dal/backend/dispatcher.hpp
@@ -282,7 +282,7 @@ template <typename Op>
 inline constexpr auto dispatch_by_cpu(const context_cpu& ctx, Op&& op) {
     using detail::cpu_extension;
 
-    const cpu_extension cpu_ex = ctx.get_enabled_cpu_extensions();
+    [[maybe_unused]] const cpu_extension cpu_ex = ctx.get_enabled_cpu_extensions();
     ONEDAL_IF_CPU_DISPATCH_AVX512(if (test_cpu_extension(cpu_ex, cpu_extension::avx512)) {
         return op(cpu_dispatch_avx512{});
     })

--- a/cpp/oneapi/dal/backend/micromkl/macro.hpp
+++ b/cpp/oneapi/dal/backend/micromkl/macro.hpp
@@ -20,11 +20,18 @@
 #error "This header cannot be included outside of micromkl module"
 #endif
 
-#define STRINGIFY(x)                     #x
-#define EXPAND(...)                      __VA_ARGS__
+#define STRINGIFY(x) #x
+#define EXPAND(...)  __VA_ARGS__
+
+#ifdef ONEDAL_REF
+#define FUNC_NAME(prefix, name)          name
+#define FUNC_NAME_CPU(cpu, prefix, name) name
+#else
 #define FUNC_NAME(prefix, name)          prefix##_##name
 #define FUNC_NAME_CPU(cpu, prefix, name) prefix##_##cpu##_##name
-#define DISPATCH_ID_NAME(cpu)            oneapi::dal::backend::cpu_dispatch_##cpu
+#endif
+
+#define DISPATCH_ID_NAME(cpu) oneapi::dal::backend::cpu_dispatch_##cpu
 
 #define FUNC_CPU_DECL(cpu, prefix, name, argdecl) \
     extern "C" void FUNC_NAME_CPU(cpu, prefix, name) argdecl;
@@ -66,6 +73,18 @@
     FUNC_SSE42(prefix, name, argdecl, argcall)  \
     FUNC_SSSE3(prefix, name, argdecl, argcall)  \
     FUNC_SSE2(prefix, name, argdecl, argcall)
+
+#ifdef ONEDAL_REF
+#define FUNC_DECL(prefix, floatabr, name, argdecl, argcall) \
+    FUNC(prefix, floatabr##name##_, argdecl, argcall)
+
+#define FUNC_CALL(prefix, floatabr, name, cargcall) floatabr##name##_<Cpu> cargcall;
+#else
+#define FUNC_DECL(prefix, floatabr, name, argdecl, argcall) \
+    FUNC(prefix, floatabr##name, argdecl, argcall)
+
+#define FUNC_CALL(prefix, floatabr, name, cargcall) prefix##_##floatabr##name<Cpu> cargcall;
+#endif
 
 #define INSTANTIATE_CPU(cpu, name, Float, argdecl) \
     template void name<DISPATCH_ID_NAME(cpu), Float> argdecl(Float);
@@ -111,8 +130,8 @@
     INSTANTIATE_SSE2(name, Float, argdecl)
 
 #define FUNC_TEMPLATE(prefix, name, fargdecl, cargdecl, fargcall, cargcall) \
-    FUNC(prefix, s##name, fargdecl(float), fargcall)                        \
-    FUNC(prefix, d##name, fargdecl(double), fargcall)                       \
+    FUNC_DECL(prefix, s, name, fargdecl(float), fargcall)                   \
+    FUNC_DECL(prefix, d, name, fargdecl(double), fargcall)                  \
                                                                             \
     namespace oneapi::dal::backend::micromkl {                              \
                                                                             \
@@ -120,10 +139,10 @@
     void name cargdecl(Float) {                                             \
         static_assert(sizeof(std::int64_t) == sizeof(DAAL_INT));            \
         if constexpr (std::is_same_v<Float, float>) {                       \
-            prefix##_s##name<Cpu> cargcall;                                 \
+            FUNC_CALL(prefix, s, name, cargcall)                            \
         }                                                                   \
         else {                                                              \
-            prefix##_d##name<Cpu> cargcall;                                 \
+            FUNC_CALL(prefix, d, name, cargcall)                            \
         }                                                                   \
     }                                                                       \
                                                                             \

--- a/cpp/oneapi/dal/backend/micromkl/micromkl.cpp
+++ b/cpp/oneapi/dal/backend/micromkl/micromkl.cpp
@@ -19,6 +19,7 @@
 #include "oneapi/dal/backend/dispatcher.hpp"
 
 #define __MICROMKL_INCLUDE_GUARD__
+
 #include "oneapi/dal/backend/micromkl/macro.hpp"
 
 /* ================================== SYEVD ================================= */
@@ -67,9 +68,13 @@
      1,                                    \
      1)
 
+#ifdef ONEDAL_REF
+FUNC_TEMPLATE(unused, syevd, SYEVD_F_DECLARGS, SYEVD_C_DECLARGS, SYEVD_F_CALLARGS, SYEVD_C_CALLARGS)
+#else
 FUNC_TEMPLATE(fpk_lapack,
               syevd,
               SYEVD_F_DECLARGS,
               SYEVD_C_DECLARGS,
               SYEVD_F_CALLARGS,
               SYEVD_C_CALLARGS)
+#endif

--- a/cpp/oneapi/dal/backend/serialization.hpp
+++ b/cpp/oneapi/dal/backend/serialization.hpp
@@ -188,6 +188,9 @@ public:
 
     // Algorithms - Linear Regression
     ID(7010000000, linear_regression_model_impl_id);
+
+    // Algorithms - KMeans
+    ID(8010000000, kmeans_clustering_model_impl_id);
 };
 
 #undef ID

--- a/cpp/oneapi/dal/test/engine/mkl/BUILD
+++ b/cpp/oneapi/dal/test/engine/mkl/BUILD
@@ -10,7 +10,10 @@ dal_test_module(
     dal_test_deps = [
         "@onedal//cpp/oneapi:include_root",
     ],
-    extra_deps = [
-        "@mkl//:mkl_seq",
-    ],
+    extra_deps = [{
+        "@config//:backend_ref": [ "@openblas//:openblas",
+                                    ],
+        "//conditions:default": [ "@mkl//:mkl_seq", 
+                                ],
+        }],
 )

--- a/dev/bazel/config/config.tpl.BUILD
+++ b/dev/bazel/config/config.tpl.BUILD
@@ -24,6 +24,22 @@ version_info(
 )
 
 config_flag(
+    name = "backend_config",
+    build_setting_default = "mkl",
+    allowed_build_setting_values = [
+        "ref",
+        "mkl",
+    ],
+)
+
+config_setting(
+    name = "backend_ref",
+    flag_values  = {
+        ":backend_config": "ref",
+    },
+)
+
+config_flag(
     name = "test_link_mode",
     build_setting_default = "dev",
     allowed_build_setting_values = [

--- a/dev/bazel/daal.bzl
+++ b/dev/bazel/daal.bzl
@@ -60,6 +60,11 @@ def daal_module(name, features=[], lib_tag="daal",
                 "DEBUG_ASSERT=1",
             ],
             "//conditions:default": [],
+        }) + select({
+            "@config//:backend_ref": [
+                "DAAL_REF",
+            ],
+            "//conditions:default": [],
         }),
         **kwargs,
     )
@@ -158,3 +163,37 @@ daal_patch_kernel_defines = rule(
     },
     toolchains = ["@onedal//dev/bazel/toolchains:extra"],
 )
+
+def _get_tool_for_backend_config_patching(ctx):
+    return ctx.toolchains["@onedal//dev/bazel/toolchains:extra"] \
+        .extra_toolchain_info.patch_daal_backend_config
+
+def _declare_patched_backend_config_header(ctx):
+    patched_path = ctx.attr.output
+    return ctx.actions.declare_file(patched_path)
+
+def _daal_patch_backend_config_impl(ctx):
+    backend_config_header = _declare_patched_backend_config_header(ctx)
+    ctx.actions.run(
+        executable = _get_tool_for_backend_config_patching(ctx),
+        arguments = [
+            ctx.file.src.path,
+            backend_config_header.path,
+            ctx.attr.backend_impl_name,
+        ],
+        inputs = [ctx.file.src],
+        outputs = [backend_config_header],
+    )
+    return [ DefaultInfo(files=depset([ backend_config_header ])) ]
+
+daal_patch_backend_config = rule(
+    implementation = _daal_patch_backend_config_impl,
+    output_to_genfiles = True,
+    attrs = {
+        "src": attr.label(allow_single_file=True, mandatory=True),
+        "output": attr.string(mandatory=True),
+        "backend_impl_name": attr.string(mandatory=True),
+    },
+    toolchains = ["@onedal//dev/bazel/toolchains:extra"],
+)
+

--- a/dev/bazel/dal.bzl
+++ b/dev/bazel/dal.bzl
@@ -502,6 +502,12 @@ def _dal_module(name, lib_tag="dal", is_dpc=False, features=[],
                 "ONEDAL_ENABLE_ASSERT=1",
             ],
             "//conditions:default": [],
+        }) + select({
+            "@config//:backend_ref": [
+                "DAAL_REF",
+                "ONEDAL_REF",
+            ],
+            "//conditions:default": [],
         }),
         deps = _expand_select(deps),
         **kwargs,

--- a/dev/bazel/deps/openblas.bzl
+++ b/dev/bazel/deps/openblas.bzl
@@ -1,0 +1,28 @@
+#===============================================================================
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+load("@onedal//dev/bazel:repos.bzl", "repos")
+
+openblas_repo = repos.prebuilt_libs_repo_rule(
+    includes = [
+        "include",
+    ],
+    libs = [
+            "lib/libopenblas.a", 
+            "lib/libgfortran.a", 
+    ],
+    build_template = "@onedal//dev/bazel/deps:openblas.tpl.BUILD",
+)

--- a/dev/bazel/deps/openblas.tpl.BUILD
+++ b/dev/bazel/deps/openblas.tpl.BUILD
@@ -1,0 +1,28 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "headers",
+    hdrs = glob(["include/**/*.h"]),
+    includes = [ "include" ],
+)
+
+cc_library(
+    name = "openblas_core",
+    #srcs = glob(["lib/libopenblas*"]),
+    srcs = [
+            "lib/libopenblas.a", 
+            "lib/libgfortran.a", 
+           ],
+    linkopts = [
+        "-lpthread",
+#        "-lgfortran",
+    ],
+)
+
+cc_library(
+    name = "openblas",
+    deps = [
+        ":headers",
+        ":openblas_core",
+    ],
+)

--- a/dev/bazel/toolchains/extra_toolchain.bzl
+++ b/dev/bazel/toolchains/extra_toolchain.bzl
@@ -21,6 +21,7 @@ load("@onedal//dev/bazel/toolchains:extra_toolchain_lnx.bzl",
 ExtraToolchainInfo = provider(
     fields = [
         "patch_daal_kernel_defines",
+        "patch_daal_backend_config",
     ],
 )
 
@@ -28,6 +29,7 @@ def _extra_toolchain_impl(ctx):
     toolchain_info = platform_common.ToolchainInfo(
         extra_toolchain_info = ExtraToolchainInfo(
             patch_daal_kernel_defines = ctx.attr.patch_daal_kernel_defines,
+            patch_daal_backend_config = ctx.attr.patch_daal_backend_config,
         ),
     )
     return [toolchain_info]
@@ -36,6 +38,7 @@ extra_toolchain = rule(
     implementation = _extra_toolchain_impl,
     attrs = {
         "patch_daal_kernel_defines": attr.string(mandatory=True),
+        "patch_daal_backend_config" : attr.string(mandatory=True), 
     },
 )
 

--- a/dev/bazel/toolchains/extra_toolchain_lnx.bzl
+++ b/dev/bazel/toolchains/extra_toolchain_lnx.bzl
@@ -19,11 +19,17 @@ def configure_extra_toolchain_lnx(repo_ctx, compiler_id):
         "patch_daal_kernel_defines.sh",
         Label("@onedal//dev/bazel/toolchains/tools:patch_daal_kernel_defines.sh"),
     )
+    repo_ctx.template(
+        "patch_daal_backend_config.sh",
+        Label("@onedal//dev/bazel/toolchains/tools:patch_daal_backend_config.sh"),
+    )
     patch_daal_kernel_defines_path = str(repo_ctx.path("patch_daal_kernel_defines.sh"))
+    patch_daal_backend_config_path = str(repo_ctx.path("patch_daal_backend_config.sh"))
     repo_ctx.template(
         "BUILD",
         Label("@onedal//dev/bazel/toolchains:extra_toolchian_lnx.tpl.BUILD"),
         {
             "%{patch_daal_kernel_defines}": patch_daal_kernel_defines_path,
+            "%{patch_daal_backend_config}": patch_daal_backend_config_path,
         }
     )

--- a/dev/bazel/toolchains/extra_toolchian_lnx.tpl.BUILD
+++ b/dev/bazel/toolchains/extra_toolchian_lnx.tpl.BUILD
@@ -5,6 +5,7 @@ load("@onedal//dev/bazel/toolchains:extra_toolchain.bzl", "extra_toolchain")
 extra_toolchain(
     name = "extra_tools",
     patch_daal_kernel_defines = "%{patch_daal_kernel_defines}",
+    patch_daal_backend_config = "%{patch_daal_backend_config}",
 )
 
 toolchain(

--- a/dev/bazel/toolchains/tools/patch_daal_backend_config.sh
+++ b/dev/bazel/toolchains/tools/patch_daal_backend_config.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#===============================================================================
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+input=$1
+output=$2
+replacement=$3
+
+sed "s/{BACKEND}/${replacement}/g" $input > $output 


### PR DESCRIPTION
Introduced required changes for selecting math/rng/service backends in case of building via bazel.
Added new build param for bazel: --backend_config=[ref|mkl] , default is 'mkl'