### PR TITLE
Change DAAL_INTEL_CPP_COMPILER to __INTEL_COMPILER

### DIFF
--- a/.ci/env/openblas.sh
+++ b/.ci/env/openblas.sh
@@ -20,6 +20,6 @@ sudo apt-get install build-essential gcc gfortran
 git clone https://github.com/xianyi/OpenBLAS.git
 pushd OpenBLAS
   make clean
-  make -j4
+  make -j4 NO_FORTRAN=1
   make install PREFIX=../__deps/open_blas
 popd

--- a/cpp/daal/include/services/daal_defines.h
+++ b/cpp/daal/include/services/daal_defines.h
@@ -28,11 +28,11 @@
 
 #include <cstddef> // for size_t
 
-#if (defined(DAAL_INTEL_CPP_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
     #define DAAL_INTEL_CPP_COMPILER
 #endif
 
-#if !(defined(_MSC_VER) || defined(DAAL_INTEL_CPP_COMPILER) || defined(__INTEL_LLVM_COMPILER))
+#if !(defined(_MSC_VER) || defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER))
     #define __int32 int
     #define __int64 long long int
 #endif
@@ -54,7 +54,7 @@
 #endif
 
 /* Intel(R) oneDAL 64-bit integer types */
-#if !(defined(DAAL_INTEL_CPP_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && defined(_MSC_VER)
+#if !(defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && defined(_MSC_VER)
     #define DAAL_INT64  __int64
     #define DAAL_UINT64 unsigned __int64
 #else
@@ -85,7 +85,7 @@
 #if defined(DAAL_HIDE_DEPRECATED)
     #define DAAL_DEPRECATED_VIRTUAL
 #else
-    #ifdef DAAL_INTEL_CPP_COMPILER
+    #ifdef __INTEL_COMPILER
         #define DAAL_DEPRECATED_VIRTUAL DAAL_DEPRECATED
     #else
         #define DAAL_DEPRECATED_VIRTUAL

--- a/cpp/daal/src/services/service_defines.h
+++ b/cpp/daal/src/services/service_defines.h
@@ -37,7 +37,7 @@ bool daal_check_is_intel_cpu();
 
 #define DAAL_CHECK_CPU_ENVIRONMENT (daal_check_is_intel_cpu())
 
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__INTEL_COMPILER)
     #define PRAGMA_IVDEP            _Pragma("ivdep")
     #define PRAGMA_NOVECTOR         _Pragma("novector")
     #define PRAGMA_VECTOR_ALIGNED   _Pragma("vector aligned")

--- a/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
+++ b/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
@@ -22,7 +22,7 @@
 
 namespace oneapi::dal::preview::subgraph_isomorphism::backend {
 
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__INTEL_COMPILER)
 #define ONEDAL_IVDEP         _Pragma("ivdep")
 #define ONEDAL_VECTOR_ALWAYS _Pragma("vector always")
 #else
@@ -32,7 +32,7 @@ namespace oneapi::dal::preview::subgraph_isomorphism::backend {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u32(std::uint32_t a) {
-#if defined(__AVX__) && defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX__) && defined(__INTEL_COMPILER)
     return _lzcnt_u32(a);
 #else
     if (a == 0)
@@ -49,7 +49,7 @@ ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u32(std::uint32_t a) {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u64(std::uint64_t a) {
-#if defined(__AVX__) && defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX__) && defined(__INTEL_COMPILER)
     return _lzcnt_u64(a);
 #else
     if (a == 0)
@@ -66,7 +66,7 @@ ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u64(std::uint64_t a) {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_popcnt64(std::uint64_t a) {
-#if defined(__AVX__) && defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX__) && defined(__INTEL_COMPILER)
     return _popcnt64(a);
 #else
     if (a == 0)

--- a/cpp/oneapi/dal/backend/common.hpp
+++ b/cpp/oneapi/dal/backend/common.hpp
@@ -23,7 +23,7 @@
 #include "oneapi/dal/array.hpp"
 #include "oneapi/dal/detail/common.hpp"
 
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__INTEL_COMPILER)
 #define PRAGMA_IVDEP         _Pragma("ivdep")
 #define PRAGMA_VECTOR_ALWAYS _Pragma("vector always")
 #else


### PR DESCRIPTION
DAAL_INTEL_CPP_COMPILER check changed back to __INTEL_COMPILER

__INTEL_COMPILER is only defined when the application is built with the **icc** compiler.
DAAL_INTEL_CPP_COMPILER must be manually defined when building with **any** of the intel compilers.
icpx only defines the __INTEL_LLVM_COMPILER macro.
icpx -fsycl defines __INTEL_LLVM_COMPILER and SYCL_LANGUAGE_VERSION macros.